### PR TITLE
Rename 'close' function to 'release'

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ function open() {
       throw error;
     })
     .finally(function() {
-      return close.call(this, connection);
+      return release.call(this, connection);
     }.bind(this));
 }
 
@@ -259,12 +259,12 @@ function keepAlive(connection) {
     });
 }
 
-function close(connection) {
+function release(connection) {
   if (!connection) return Promise.resolve();
 
   return this.pool.releaseAsync(connection)
     .catch(function(error) {
-      log.error('Unable to close connection: ' + connection.uuid);
+      log.error('Unable to release connection: ' + connection.uuid);
       throw error;
     });
 }


### PR DESCRIPTION
Renaming this because the current name is a lie. This function does not "close" the connection, it releases the connection back into the connection pool.

This is not a breaking change, because the `close` function is internal.