### PR TITLE
Change 'initialize' error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ function initialize() {
       return pool;
     }.bind(this))
     .catch(function(error) {
-      log.error('Unable to connect to database: ' + jdbcConfig.url);
+      log.error('Unable to connect to server: ' + jdbcConfig.url);
       throw error;
     });
 }


### PR DESCRIPTION
Current message is not entirely accurate: it's true that it is unable to connect to the "database", but that's because it was unable to connect to the "server" 😜 